### PR TITLE
Fix uninitialized `invalid` variable error

### DIFF
--- a/logrotee.cpp
+++ b/logrotee.cpp
@@ -34,7 +34,7 @@ private:
 	
 public:
 	Arguments(int argc, char *argv[])
-			: chunkSize(DEFAULT_CHUNK_SIZE)
+			: chunkSize(DEFAULT_CHUNK_SIZE), invalid(false)
 	{
 		int getoptResult;
 		


### PR DESCRIPTION
Hello!
I've tried to use this utility and found different behaviour on two different linux machines with same logrotee binary.
After investigation I found that `invalid` is unitialized, maybe some different bytes wasn't cleared before constructor call.

Thank you